### PR TITLE
Add Minimum NodeJs Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Proc. ACM Program. Lang. 4(OOPSLA): 187:1-187:25 (2020)
 
 ## Installing
 
+Running this application requires NodeJs 15 or later 
+
 ```bash
 npm install -g @cs-au-dk/jelly
 ```


### PR DESCRIPTION
Nullish Assignment requires at least NodeJS 15
[Nullish Assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment)