### PR TITLE
approx: stub Blob/File/URL.createObjectURL to avoid a native SIGABRT …

### DIFF
--- a/src/approx/sandbox.ts
+++ b/src/approx/sandbox.ts
@@ -63,6 +63,13 @@ export function patchGlobalBuiltins() {
     // DOM specific interface
     g.window = g.document = theProxy;
 
+    // Blob/File and URL.createObjectURL/revokeObjectURL: on Node >=22, feeding a
+    // Proxy placeholder into these aborts the process with a native SIGABRT
+    // (Blob::New / Blob::StoreDataObject) rather than a catchable exception.
+    g.Blob = g.File = theProxy;
+    if (g.URL)
+        g.URL.createObjectURL = g.URL.revokeObjectURL = theProxy;
+
     // freeze objects and properties
     for (const x of [
         Array, ArrayBuffer, BigInt, Boolean, DataView, Date, /*Error,*/ AggregateError, EvalError, RangeError, ReferenceError,


### PR DESCRIPTION
…on Node >=22

The --approx sandbox force-executes library code with `theProxy` placeholders standing in for unresolved values. On Node >=22, passing such a placeholder into the Blob family aborts the whole process with a native SIGABRT instead of a catchable JS exception:

  - `new Blob(<proxy>)`             -> Blob::New
  - `URL.createObjectURL(<proxy>)`  -> Blob::StoreDataObject

Any analysed path that constructs a Blob/File or creates an object URL takes the whole analysis down (common in React Native / web app closures).

patchGlobalBuiltins() already neutralises the other risky host globals (Worker, window, document, fetch, ...); Blob, File, and URL.createObjectURL / revokeObjectURL were simply missing. Stub them with the same theProxy; the `g.URL` guard keeps it safe where URL is absent.